### PR TITLE
Add local properties

### DIFF
--- a/src/DrupalFinder.php
+++ b/src/DrupalFinder.php
@@ -102,4 +102,18 @@ class DrupalFinder {
     return FALSE;
   }
 
+  /**
+   * @return string
+   */
+  public function getDrupalRoot() {
+    return $this->drupalRoot;
+  }
+
+  /**
+   * @return string
+   */
+  public function getProjectRoot() {
+    return $this->projectRoot;
+  }
+
 }

--- a/src/DrupalFinder.php
+++ b/src/DrupalFinder.php
@@ -71,7 +71,7 @@ class DrupalFinder {
   /**
    * @param $path
    *
-   * @return string|FALSE
+   * @return boolean
    */
   public function isValidRoot($path) {
     if (!empty($path) && is_dir($path) && file_exists($path . '/autoload.php')) {
@@ -80,7 +80,8 @@ class DrupalFinder {
       $candidate = 'core/includes/common.inc';
       if (file_exists($path . '/' . $candidate) && file_exists($path . '/core/core.services.yml')) {
         if (file_exists($path . '/core/misc/drupal.js') || file_exists($path . '/core/assets/js/drupal.js')) {
-          return $path;
+          $this->projectRoot = $path;
+          $this->drupalRoot = $path;
         }
       }
     }
@@ -90,7 +91,9 @@ class DrupalFinder {
         if (isset($json['extra']['installer-paths']) && is_array($json['extra']['installer-paths'])) {
           foreach ($json['extra']['installer-paths'] as $install_path => $items) {
             if (in_array('type:drupal-core', $items)) {
-              return $path . '/' . substr($install_path, 0, -5);
+              $this->projectRoot = $path;
+              $this->drupalRoot = $path . '/' . substr($install_path, 0, -5);
+              return TRUE;
             }
           }
         }

--- a/src/DrupalFinder.php
+++ b/src/DrupalFinder.php
@@ -9,6 +9,16 @@ namespace DrupalFinder;
 
 class DrupalFinder {
 
+  /**
+   * @var string
+   */
+  private $drupalRoot;
+
+  /**
+   * @var string
+   */
+  private $projectRoot;
+
   public function locateRoot($start_path) {
     $drupal_root = FALSE;
 

--- a/src/DrupalFinder.php
+++ b/src/DrupalFinder.php
@@ -10,14 +10,18 @@ namespace DrupalFinder;
 class DrupalFinder {
 
   /**
+   * Drupal web public directory.
+   *
    * @var string
    */
   private $drupalRoot;
 
   /**
+   * Drupal package composer directory.
+   *
    * @var string
    */
-  private $projectRoot;
+  private $composerRoot;
 
   public function locateRoot($start_path) {
     $drupal_root = FALSE;
@@ -80,7 +84,7 @@ class DrupalFinder {
       $candidate = 'core/includes/common.inc';
       if (file_exists($path . '/' . $candidate) && file_exists($path . '/core/core.services.yml')) {
         if (file_exists($path . '/core/misc/drupal.js') || file_exists($path . '/core/assets/js/drupal.js')) {
-          $this->projectRoot = $path;
+          $this->composerRoot = $path;
           $this->drupalRoot = $path;
         }
       }
@@ -91,7 +95,7 @@ class DrupalFinder {
         if (isset($json['extra']['installer-paths']) && is_array($json['extra']['installer-paths'])) {
           foreach ($json['extra']['installer-paths'] as $install_path => $items) {
             if (in_array('type:drupal-core', $items)) {
-              $this->projectRoot = $path;
+              $this->composerRoot = $path;
               $this->drupalRoot = $path . '/' . substr($install_path, 0, -5);
               return TRUE;
             }
@@ -112,8 +116,8 @@ class DrupalFinder {
   /**
    * @return string
    */
-  public function getProjectRoot() {
-    return $this->projectRoot;
+  public function getComposerRoot() {
+    return $this->composerRoot;
   }
 
 }


### PR DESCRIPTION
* Add `drupalRoot` and `projectRoot` local scope properties. 
* Make sure isValidRoot returns a boolean.
* Add getters for local properties.

NOTE: Not too happy with `projectRoot` maybe `composerRoot` will be better

Usage instructions:
```
use DrupalFinder\DrupalFinder;

$drupalFinder = new DrupalFinder();
$drupalFinder->locateRoot(‘path/to/drupal');
$drupalRoot = $drupalFinder->getDrupalRoot();
$projectRoot = $drupalFinder->getProjectRoot();
```
