### PR TITLE
Test symlink

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,0 +1,1 @@
+preset: psr2

--- a/README.md
+++ b/README.md
@@ -8,12 +8,17 @@ Drupal Finder provides a class to locate a Drupal installation in a given path.
 
 ```
 $drupalFinder = new \DrupalFinder\DrupalFinder();
-$drupalRoot = $drupalFinder->locateRoot(getcwd());
+if ($drupalFinder->locateRoot(getcwd())) {
+    $drupalRoot = $drupalFinder->getDrupalRoot());
+    $composerRoot = $drupalFinder->getComposerRoot());
+    ...
+}
 ```
 
-## Example
+## Examples
 
-[Drush Shim](https://github.com/webflo/drush-shim)
+- [Drupal Console Launcher](https://github.com/hechoendrupal/drupal-console-launcher/blob/master/bin/drupal.php)
+- [Drush Shim](https://github.com/webflo/drush-shim) (with webflo/drupal-finder:^0.0.1)
 
 ## License
 

--- a/src/DrupalFinder.php
+++ b/src/DrupalFinder.php
@@ -58,17 +58,12 @@ class DrupalFinder {
    * @param string
    *   Path to start from.
    *
-   * @return string
-   *   Parent path of given path.
+   * @return string|FALSE
+   *   Parent path of given path or false when $path is filesystem root.
    */
-  public function shiftPathUp($path) {
-    if (empty($path)) {
-      return FALSE;
-    }
-    $path = explode(DIRECTORY_SEPARATOR, $path);
-    // Move one directory up.
-    array_pop($path);
-    return implode(DIRECTORY_SEPARATOR, $path);
+  private function shiftPathUp($path) {
+    $parent = dirname($path);
+    return in_array($parent, ['.', $path]) ? FALSE : $parent;
   }
 
   /**

--- a/src/DrupalFinder.php
+++ b/src/DrupalFinder.php
@@ -19,7 +19,7 @@ class DrupalFinder {
   /**
    * Drupal package composer directory.
    *
-   * @var string
+   * @var boolean
    */
   private $composerRoot;
 
@@ -33,8 +33,8 @@ class DrupalFinder {
         $path = realpath($path);
       }
       // Check the start path.
-      if ($checked_path = $this->isValidRoot($path)) {
-        return $checked_path;
+      if ($this->isValidRoot($path)) {
+        return TRUE;
       }
       else {
         // Move up dir by dir and check each.
@@ -42,8 +42,8 @@ class DrupalFinder {
           if ($follow_symlinks && is_link($path)) {
             $path = realpath($path);
           }
-          if ($checked_path = $this->isValidRoot($path)) {
-            return $checked_path;
+          if ($this->isValidRoot($path)) {
+            return TRUE;
           }
         }
       }
@@ -69,7 +69,7 @@ class DrupalFinder {
   /**
    * @param $path
    *
-   * @return string|FALSE
+   * @return boolean
    */
   protected function isValidRoot($path) {
     if (!empty($path) && is_dir($path) && file_exists($path . '/autoload.php') && file_exists($path . '/composer.json')) {

--- a/tests/DrupalFinderTest.php
+++ b/tests/DrupalFinderTest.php
@@ -116,7 +116,7 @@ class DrupalFinderTest extends PHPUnit_Framework_TestCase {
     $this->assertSame($root, $this->finder->getComposerRoot());
   }
 
-  public function testDrupalComposerStructureWithSymlink() {
+  public function testDrupalComposerStructureWithRealFilesystem() {
     $root = $this->tempdir(sys_get_temp_dir());
     $this->dumpToFileSystem($this->getDrupalComposerStructure(), $root);
 

--- a/tests/DrupalFinderTest.php
+++ b/tests/DrupalFinderTest.php
@@ -144,7 +144,20 @@ class DrupalFinderTest extends PHPUnit_Framework_TestCase {
       $path = $dir . $prefix . mt_rand(0, 9999999);
     }
     while (!mkdir($path, $mode));
+    register_shutdown_function(['DrupalFinderTest', 'tempdir_remove'], $path);
     return realpath($path);
+  }
+
+  static function tempdir_remove($path) {
+    $scandir = is_link($path) ? [] : scandir($path);
+    foreach ($scandir as $child) {
+      if (in_array($child, ['.', '..'])) {
+        continue;
+      }
+      $child = "$path/$child";
+      is_dir($child) ? static::tempdir_remove($child) : unlink($child);
+    }
+    rmdir($path);
   }
 
 }

--- a/tests/DrupalFinderTest.php
+++ b/tests/DrupalFinderTest.php
@@ -103,8 +103,8 @@ class DrupalFinderTest extends PHPUnit_Framework_TestCase {
     symlink($root, $symlink . '/foo');
 
     $this->assertTrue($this->finder->locateRoot($symlink . '/foo'));
-    $this->assertSame(realpath($root), $this->finder->getDrupalRoot());
-    $this->assertSame(realpath($root), $this->finder->getComposerRoot());
+    $this->assertSame($root, $this->finder->getDrupalRoot());
+    $this->assertSame($root, $this->finder->getComposerRoot());
   }
 
   public function testDrupalComposerStructureWithSymlink() {
@@ -120,8 +120,8 @@ class DrupalFinderTest extends PHPUnit_Framework_TestCase {
     symlink($root, $symlink . '/foo');
 
     $this->assertTrue($this->finder->locateRoot($symlink . '/foo'));
-    $this->assertSame(realpath($root . '/web'), $this->finder->getDrupalRoot());
-    $this->assertSame(realpath($root), $this->finder->getComposerRoot());
+    $this->assertSame($root . '/web', $this->finder->getDrupalRoot());
+    $this->assertSame($root, $this->finder->getComposerRoot());
   }
 
   protected function dumpToFileSystem($fileStructure, $root) {
@@ -144,7 +144,7 @@ class DrupalFinderTest extends PHPUnit_Framework_TestCase {
       $path = $dir . $prefix . mt_rand(0, 9999999);
     }
     while (!mkdir($path, $mode));
-    return $path;
+    return realpath($path);
   }
 
 }

--- a/tests/DrupalFinderTest.php
+++ b/tests/DrupalFinderTest.php
@@ -21,6 +21,7 @@ class DrupalFinderTest extends PHPUnit_Framework_TestCase {
       ],
       'core.services.yml' => '',
     ],
+    'modules' => [],
   ];
 
   /**
@@ -130,6 +131,19 @@ class DrupalFinderTest extends PHPUnit_Framework_TestCase {
     $this->assertTrue($this->finder->locateRoot($symlink . '/foo'));
     $this->assertSame($root . '/web', $this->finder->getDrupalRoot());
     $this->assertSame($root, $this->finder->getComposerRoot());
+  }
+
+  public function testDrupalWithLinkedModule() {
+    $root = $this->tempdir(sys_get_temp_dir());
+    $this->dumpToFileSystem(static::$fileStructure, $root);
+
+    $module = $this->tempdir(sys_get_temp_dir());
+    $module_link = $root . '/modules/foo';
+    $this->symlink($module, $module_link);
+
+    $this->assertTrue($this->finder->locateRoot($module_link));
+    $this->assertSame($root, realpath($this->finder->getDrupalRoot()));
+    $this->assertSame($root, realpath($this->finder->getComposerRoot()));
   }
 
   protected function dumpToFileSystem($fileStructure, $root) {

--- a/tests/DrupalFinderTest.php
+++ b/tests/DrupalFinderTest.php
@@ -100,7 +100,7 @@ class DrupalFinderTest extends PHPUnit_Framework_TestCase {
 
     // Test symlink implementation
     $symlink = $this->tempdir(sys_get_temp_dir());
-    symlink($root, $symlink . '/foo');
+    $this->symlink($root, $symlink . '/foo');
 
     $this->assertTrue($this->finder->locateRoot($symlink . '/foo'));
     $this->assertSame($root, $this->finder->getDrupalRoot());
@@ -117,7 +117,7 @@ class DrupalFinderTest extends PHPUnit_Framework_TestCase {
 
     // Test symlink implementation
     $symlink = $this->tempdir(sys_get_temp_dir());
-    symlink($root, $symlink . '/foo');
+    $this->symlink($root, $symlink . '/foo');
 
     $this->assertTrue($this->finder->locateRoot($symlink . '/foo'));
     $this->assertSame($root . '/web', $this->finder->getDrupalRoot());
@@ -160,4 +160,31 @@ class DrupalFinderTest extends PHPUnit_Framework_TestCase {
     rmdir($path);
   }
 
+
+  /**
+   * @param $target
+   * @param $link
+   *
+   * @throws PHPUnit_Framework_SkippedTestError
+   *
+   */
+  private function symlink($target, $link) {
+    try {
+      return symlink($target, $link);
+    } catch (Exception $e) {
+      if (
+        defined('PHP_WINDOWS_VERSION_BUILD')
+        && strstr($e->getMessage(), WIN_ERROR_PRIVILEGE_NOT_HELD)
+      ) {
+        $this->markTestSkipped(<<<'MESSAGE'
+No privilege to create symlinks. Run test as Administrator (elevated process).
+MESSAGE
+);
+      }
+      throw $e;
+    }
+  }
+
 }
+
+define('WIN_ERROR_PRIVILEGE_NOT_HELD', '1314');

--- a/tests/DrupalFinderTest.php
+++ b/tests/DrupalFinderTest.php
@@ -23,6 +23,29 @@ class DrupalFinderTest extends PHPUnit_Framework_TestCase {
     ],
   ];
 
+  /**
+   * @return array
+   */
+  protected function getDrupalComposerStructure() {
+    $fileStructure = [
+      'web' => static::$fileStructure,
+      'composer.json' => json_encode([
+        'require' => [
+          'drupal/core' => '*'
+        ],
+        'extra' => [
+          'installer-paths' => [
+            'web/core' => [
+              'type:drupal-core'
+            ],
+          ],
+        ],
+      ])
+    ];
+    unset($fileStructure['web']['composer.json']);
+    return $fileStructure;
+  }
+
   protected function setUp() {
     parent::setUp();
     $this->finder = new \DrupalFinder\DrupalFinder();
@@ -46,22 +69,7 @@ class DrupalFinderTest extends PHPUnit_Framework_TestCase {
   }
 
   public function testDrupalComposerStructure() {
-    $fileStructure = [
-      'web' => static::$fileStructure,
-      'composer.json' => json_encode([
-        'require' => [
-          'drupal/core' => '*'
-        ],
-        'extra' => [
-          'installer-paths' => [
-            'web/core' => [
-              'type:drupal-core'
-            ],
-          ],
-        ],
-      ])
-    ];
-    unset($fileStructure['web']['composer.json']);
+    $fileStructure = $this->getDrupalComposerStructure();
 
     $root = vfsStream::setup('root', null, $fileStructure);
     $this->assertTrue($this->finder->locateRoot($root->url() . '/web'));
@@ -80,6 +88,63 @@ class DrupalFinderTest extends PHPUnit_Framework_TestCase {
     $this->assertFalse($this->finder->locateRoot($root->url()));
     $this->assertFalse($this->finder->getDrupalRoot());
     $this->assertFalse($this->finder->getComposerRoot());
+  }
+
+  public function testWithRealFilesystem() {
+    $root = $this->tempdir(sys_get_temp_dir());
+    $this->dumpToFileSystem(static::$fileStructure, $root);
+
+    $this->assertTrue($this->finder->locateRoot($root));
+    $this->assertSame($root, $this->finder->getDrupalRoot());
+    $this->assertSame($root, $this->finder->getComposerRoot());
+
+    // Test symlink implementation
+    $symlink = $this->tempdir(sys_get_temp_dir());
+    symlink($root, $symlink . '/foo');
+
+    $this->assertTrue($this->finder->locateRoot($symlink . '/foo'));
+    $this->assertSame(realpath($root), $this->finder->getDrupalRoot());
+    $this->assertSame(realpath($root), $this->finder->getComposerRoot());
+  }
+
+  public function testDrupalComposerStructureWithSymlink() {
+    $root = $this->tempdir(sys_get_temp_dir());
+    $this->dumpToFileSystem($this->getDrupalComposerStructure(), $root);
+
+    $this->assertTrue($this->finder->locateRoot($root));
+    $this->assertSame($root . '/web', $this->finder->getDrupalRoot());
+    $this->assertSame($root, $this->finder->getComposerRoot());
+
+    // Test symlink implementation
+    $symlink = $this->tempdir(sys_get_temp_dir());
+    symlink($root, $symlink . '/foo');
+
+    $this->assertTrue($this->finder->locateRoot($symlink . '/foo'));
+    $this->assertSame(realpath($root . '/web'), $this->finder->getDrupalRoot());
+    $this->assertSame(realpath($root), $this->finder->getComposerRoot());
+  }
+
+  protected function dumpToFileSystem($fileStructure, $root) {
+    foreach ($fileStructure as $name => $content) {
+      if (is_array($content)) {
+        mkdir($root . '/' . $name);
+        $this->dumpToFileSystem($content, $root . '/' . $name);
+      }
+      else {
+        file_put_contents($root . '/' . $name, $content);
+      }
+    }
+  }
+
+  protected function tempdir($dir, $prefix = '', $mode = 0700) {
+    if (substr($dir, -1) != '/') {
+      $dir .= '/';
+    }
+    do {
+      $path = $dir . $prefix . mt_rand(0, 9999999);
+    }
+    while (!mkdir($path, $mode));
+    return $path;
   }
 
 }

--- a/tests/DrupalFinderTest.php
+++ b/tests/DrupalFinderTest.php
@@ -149,8 +149,16 @@ class DrupalFinderTest extends PHPUnit_Framework_TestCase {
   }
 
   static function tempdir_remove($path) {
-    $scandir = is_link($path) ? [] : scandir($path);
-    foreach ($scandir as $child) {
+    if (is_link($path)) {
+      if (defined('PHP_WINDOWS_VERSION_BUILD')){
+        rmdir($path);
+      } else {
+        unlink($path);
+      }
+      return;
+    }
+
+    foreach (scandir($path) as $child) {
       if (in_array($child, ['.', '..'])) {
         continue;
       }

--- a/tests/DrupalFinderTest.php
+++ b/tests/DrupalFinderTest.php
@@ -90,7 +90,7 @@ class DrupalFinderTest extends PHPUnit_Framework_TestCase {
     $this->assertFalse($this->finder->getComposerRoot());
   }
 
-  public function testWithRealFilesystem() {
+  public function testDrupalDefaultStructureWithRealFilesystem() {
     $root = $this->tempdir(sys_get_temp_dir());
     $this->dumpToFileSystem(static::$fileStructure, $root);
 

--- a/tests/DrupalFinderTest.php
+++ b/tests/DrupalFinderTest.php
@@ -90,6 +90,14 @@ class DrupalFinderTest extends PHPUnit_Framework_TestCase {
     $this->assertFalse($this->finder->getComposerRoot());
   }
 
+  public function testNoDrupalRootWithRealFilesystem() {
+    $root = $this->tempdir(sys_get_temp_dir());
+
+    $this->assertFalse($this->finder->locateRoot($root));
+    $this->assertFalse($this->finder->getDrupalRoot());
+    $this->assertFalse($this->finder->getComposerRoot());
+  }
+
   public function testDrupalDefaultStructureWithRealFilesystem() {
     $root = $this->tempdir(sys_get_temp_dir());
     $this->dumpToFileSystem(static::$fileStructure, $root);


### PR DESCRIPTION
Added some more tests:
 - no Drupal Root in any parent
 - Drupal with linked Module

Symlinks are possible on Windows, needs to run as Admin.

Made shiftPathUp work on Windows with forward slashes in path.

@webflo you're allowed to commit to luenemam/test-symlink