### PR TITLE
Fail to detect right composer root when drupal/core in subfolder.

### DIFF
--- a/src/DrupalFinder.php
+++ b/src/DrupalFinder.php
@@ -81,8 +81,11 @@ class DrupalFinder
             $candidate = 'core/includes/common.inc';
             if (file_exists($path . '/' . $candidate) && file_exists($path . '/core/core.services.yml')) {
                 if (file_exists($path . '/core/misc/drupal.js') || file_exists($path . '/core/assets/js/drupal.js')) {
-                    $this->composerRoot = $path;
-                    $this->drupalRoot = $path;
+                    // A valid composer root has a vendor directory in it.
+                    if (is_dir($path . '/vendor')) {
+                        $this->composerRoot = $path;
+                        $this->drupalRoot = $path;
+                    }
                 }
             }
         }


### PR DESCRIPTION
When using drupal composer project template:

https://github.com/drupal-composer/drupal-project

You get a folder structure such as:

/my-project
/my-project/vendor
/my-project/web

Where drupal core is installed inside the /web directory.

If you use the directory "/myproject/web" in isValidRoot($path) current implementation will say this is a valid drupal/composer root, but this is wrong, because the composer root is one level up. It will then fail to loop up a level to find the right composer and drupal root directories.