### PR TITLE
Remove superfluous parentheses

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Drupal Finder provides a class to locate a Drupal installation in a given path.
 ```
 $drupalFinder = new \DrupalFinder\DrupalFinder();
 if ($drupalFinder->locateRoot(getcwd())) {
-    $drupalRoot = $drupalFinder->getDrupalRoot());
-    $composerRoot = $drupalFinder->getComposerRoot());
+    $drupalRoot = $drupalFinder->getDrupalRoot();
+    $composerRoot = $drupalFinder->getComposerRoot();
     ...
 }
 ```


### PR DESCRIPTION
In Drupal Finder example (README.md) you have too many closing parentheses. This pull request removes superfluous parentheses.