### PR TITLE
Trim `/core` from $install_path for better D7 support.

### DIFF
--- a/src/DrupalFinder.php
+++ b/src/DrupalFinder.php
@@ -107,10 +107,9 @@ class DrupalFinder
                     foreach ($json['extra']['installer-paths'] as $install_path => $items) {
                         if (in_array('type:drupal-core', $items) || in_array('drupal/core', $items)) {
                             $this->composerRoot = $path;
-                            $this->drupalRoot = $path . '/' . substr(
-                                $install_path,
-                                0,
-                                -5
+                            $this->drupalRoot = $path . '/' . rtrim(
+                              $install_path,
+                                '/core'
                             );
                             $this->vendorDir = $this->composerRoot . '/vendor';
                         }


### PR DESCRIPTION
Specifically strip `/core` from the core install path as core is not in the D7 path -- https://github.com/drupal-composer/drupal-project/blob/7.x/composer.json#L41