### PR TITLE
Allow for alternate name for composer.json.

### DIFF
--- a/src/DrupalFinder.php
+++ b/src/DrupalFinder.php
@@ -85,7 +85,7 @@ class DrupalFinder
      */
     protected function isValidRoot($path)
     {
-        if (!empty($path) && is_dir($path) && file_exists($path . '/autoload.php') && file_exists($path . '/'. $this->getComposerFileName())) {
+        if (!empty($path) && is_dir($path) && file_exists($path . '/autoload.php') && file_exists($path . '/' . $this->getComposerFileName())) {
             // Additional check for the presence of core/composer.json to
             // grant it is not a Drupal 7 site with a base folder named "core".
             $candidate = 'core/includes/common.inc';

--- a/src/DrupalFinder.php
+++ b/src/DrupalFinder.php
@@ -85,7 +85,7 @@ class DrupalFinder
      */
     protected function isValidRoot($path)
     {
-        if (!empty($path) && is_dir($path) && file_exists($path . '/autoload.php') && file_exists($path . '/composer.json')) {
+        if (!empty($path) && is_dir($path) && file_exists($path . '/autoload.php') && file_exists($path . '/'. $this->getComposerFileName())) {
             // Additional check for the presence of core/composer.json to
             // grant it is not a Drupal 7 site with a base folder named "core".
             $candidate = 'core/includes/common.inc';
@@ -97,9 +97,9 @@ class DrupalFinder
                 }
             }
         }
-        if (!empty($path) && is_dir($path) && file_exists($path . '/composer.json')) {
+        if (!empty($path) && is_dir($path) && file_exists($path . '/' . $this->getComposerFileName())) {
             $json = json_decode(
-                file_get_contents($path . '/composer.json'),
+                file_get_contents($path . '/' . $this->getComposerFileName()),
                 true
             );
             if (is_array($json)) {
@@ -122,9 +122,9 @@ class DrupalFinder
                 }
             }
         }
-        if ($this->composerRoot && file_exists($this->composerRoot . '/composer.json')) {
+        if ($this->composerRoot && file_exists($this->composerRoot . '/' . $this->getComposerFileName())) {
             $json = json_decode(
-                file_get_contents($path . '/composer.json'),
+                file_get_contents($path . '/' . $this->getComposerFileName()),
                 true
             );
             if (is_array($json) && isset($json['config']['vendor-dir'])) {
@@ -150,6 +150,14 @@ class DrupalFinder
     {
         return $this->composerRoot;
     }
+
+  /**
+   * @return string
+   */
+  public function getComposerFileName()
+  {
+    return getenv('COMPOSER') ?: 'composer.json';
+  }
 
     /**
      * @return string

--- a/src/DrupalFinder.php
+++ b/src/DrupalFinder.php
@@ -151,13 +151,13 @@ class DrupalFinder
         return $this->composerRoot;
     }
 
-  /**
-   * @return string
-   */
-  public function getComposerFileName()
-  {
-    return getenv('COMPOSER') ?: 'composer.json';
-  }
+    /**
+     * @return string
+     */
+    protected function getComposerFileName()
+    {
+        return trim(getenv('COMPOSER')) ?: 'composer.json';
+    }
 
     /**
      * @return string


### PR DESCRIPTION
This env variable is used by Unish, Drush's test suite. It may help solve #20 as well.

This feature would allow https://github.com/drush-ops/drush/pull/3087 to go green.