### PR TITLE
Add support for drupal-composer-helper plugin

### DIFF
--- a/src/DrupalFinder.php
+++ b/src/DrupalFinder.php
@@ -120,6 +120,12 @@ class DrupalFinder
                         }
                     }
                 }
+                elseif (isset($json['extra']['drupal-composer-helper']) && is_array($json['extra']['drupal-composer-helper'])) {
+                    $web_prefix = isset($json['extra']['drupal-composer-helper']['web-prefix']) ? $json['extra']['drupal-composer-helper']['web-prefix'] : 'web';
+                    $this->composerRoot = $path;
+                    $this->drupalRoot = $path . '/' . $web_prefix;
+                    $this->vendorDir = $path . '/vendor';
+                }
             }
         }
         if ($this->composerRoot && file_exists($this->composerRoot . '/composer.json')) {

--- a/src/DrupalFinder.php
+++ b/src/DrupalFinder.php
@@ -119,8 +119,8 @@ class DrupalFinder
                             $this->vendorDir = $this->composerRoot . '/vendor';
                         }
                     }
-                } elseif (isset($json['extra']['drupal-composer-helper']) && is_array($json['extra']['drupal-composer-helper'])) {
-                    $web_prefix = isset($json['extra']['drupal-composer-helper']['web-prefix']) ? $json['extra']['drupal-composer-helper']['web-prefix'] : 'web';
+                } elseif (!empty($json['extra']['drupal-web-dir'])) {
+                    $web_prefix = $json['extra']['drupal-web-dir'];
                     $this->composerRoot = $path;
                     $this->drupalRoot = $path . '/' . $web_prefix;
                     $this->vendorDir = $path . '/vendor';

--- a/src/DrupalFinder.php
+++ b/src/DrupalFinder.php
@@ -119,8 +119,7 @@ class DrupalFinder
                             $this->vendorDir = $this->composerRoot . '/vendor';
                         }
                     }
-                }
-                elseif (isset($json['extra']['drupal-composer-helper']) && is_array($json['extra']['drupal-composer-helper'])) {
+                } elseif (isset($json['extra']['drupal-composer-helper']) && is_array($json['extra']['drupal-composer-helper'])) {
                     $web_prefix = isset($json['extra']['drupal-composer-helper']['web-prefix']) ? $json['extra']['drupal-composer-helper']['web-prefix'] : 'web';
                     $this->composerRoot = $path;
                     $this->drupalRoot = $path . '/' . $web_prefix;


### PR DESCRIPTION
The new [drupal-composer-helper](https://github.com/hussainweb/drupal-composer-helper) plugin aims to reduce complexity in setting up and maintaining Drupal sites based on composer. As one of its improvements, it removes the necessity of explicitly specifying `installer-paths` in `extra` section of `composer.json` (it's still supported but not necessary). Unfortunately, this breaks tools like drush and drupal console as indicated in hussainweb/drupal-composer-helper#9.

I have outlined a workaround in that issue and I am trying to add support to drupal-finder to detect sites based on drupal-composer-helper plugin. I have tested this fix on my local install and it fixes the problem mentioned in hussainweb/drupal-composer-helper#9.