### PR TITLE
Add missing requirement.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,9 @@
             "email": "florian@webflo.org"
         }
     ],
-    "require": {},
+    "require": {
+        "ext-json": "*"
+    },
     "autoload": {
         "classmap": [
             "src/DrupalFinder.php"


### PR DESCRIPTION
PHPStorm was so nice to tell me about the missing requirement for `json_decode()`.