### PR TITLE
drupal-finder is unable to find the drupal-root directory when installed in a subdirectory

### DIFF
--- a/tests/Drupal8FinderTest.php
+++ b/tests/Drupal8FinderTest.php
@@ -214,7 +214,8 @@ class Drupal8FinderTest extends DrupalFinderTestBase
         $this->assertSame($root . '/vendor', $this->finder->getVendorDir());
     }
 
-    public function testDrupalDefaultStructureWithRealFilesystemInSubdirectory() {
+    public function testDrupalDefaultStructureWithRealFilesystemInSubdirectory() 
+    {
         $root = $this->tempdir(sys_get_temp_dir()) . '/subdir';
         mkdir($root);
         mkdir($root . '/htdocs');

--- a/tests/Drupal8FinderTest.php
+++ b/tests/Drupal8FinderTest.php
@@ -214,7 +214,7 @@ class Drupal8FinderTest extends DrupalFinderTestBase
         $this->assertSame($root . '/vendor', $this->finder->getVendorDir());
     }
 
-    public function testDrupalDefaultStructureWithRealFilesystemInSubdirectory() 
+    public function testDrupalDefaultStructureWithRealFilesystemInSubdirectory()
     {
         $root = $this->tempdir(sys_get_temp_dir()) . '/subdir';
         mkdir($root);

--- a/tests/Drupal8FinderTest.php
+++ b/tests/Drupal8FinderTest.php
@@ -215,17 +215,17 @@ class Drupal8FinderTest extends DrupalFinderTestBase
     }
 
     public function testDrupalDefaultStructureWithRealFilesystemInSubdirectory() {
-      $root = $this->tempdir(sys_get_temp_dir()) . '/subdir';
-      mkdir($root);
-      mkdir($root . '/htdocs');
-      $this->dumpToFileSystem(static::$fileStructure, $root . '/htdocs');
+        $root = $this->tempdir(sys_get_temp_dir()) . '/subdir';
+        mkdir($root);
+        mkdir($root . '/htdocs');
+        $this->dumpToFileSystem(static::$fileStructure, $root . '/htdocs');
 
-      $symlink = $this->tempdir(sys_get_temp_dir());
-      $this->symlink($root, $symlink . '/foo');
+        $symlink = $this->tempdir(sys_get_temp_dir());
+        $this->symlink($root, $symlink . '/foo');
 
-      $this->finder->locateRoot($symlink . '/foo/htdocs');
+        $this->finder->locateRoot($symlink . '/foo/htdocs');
 
-      $this->assertSame($root, $this->finder->getDrupalRoot());
+        $this->assertSame($root, $this->finder->getDrupalRoot());
     }
 
     public function testDrupalWithLinkedModule()

--- a/tests/Drupal8FinderTest.php
+++ b/tests/Drupal8FinderTest.php
@@ -214,6 +214,20 @@ class Drupal8FinderTest extends DrupalFinderTestBase
         $this->assertSame($root . '/vendor', $this->finder->getVendorDir());
     }
 
+    public function testDrupalDefaultStructureWithRealFilesystemInSubdirectory() {
+      $root = $this->tempdir(sys_get_temp_dir()) . '/subdir';
+      mkdir($root);
+      mkdir($root . '/htdocs');
+      $this->dumpToFileSystem(static::$fileStructure, $root . '/htdocs');
+
+      $symlink = $this->tempdir(sys_get_temp_dir());
+      $this->symlink($root, $symlink . '/foo');
+
+      $this->finder->locateRoot($symlink . '/foo/htdocs');
+
+      $this->assertSame($root, $this->finder->getDrupalRoot());
+    }
+
     public function testDrupalWithLinkedModule()
     {
         $root = $this->tempdir(sys_get_temp_dir());


### PR DESCRIPTION
Follow-up from issue mentioned in drush-ops/drush#4019.

When Drupal is installed in a subdirectory, drupal-finder is unable to find the drupal-root directory.

To reproduce using drush: 

1. e.g. Site is located in /var/www/release/1.0.0/htdocs
2. Create a symlink /var/www/current -> /var/www/release/1.0.0
3. The website is now accessible in /var/www/current/htdocs.
4. Execute drush in /var/www/current/htdocs.

Or see the test in this pull request.