### PR TITLE
Throw an exception when invalid composer.json is found.

### DIFF
--- a/src/DrupalFinder.php
+++ b/src/DrupalFinder.php
@@ -102,6 +102,11 @@ class DrupalFinder
                 file_get_contents($path . '/' . $this->getComposerFileName()),
                 true
             );
+
+            if (is_null($json)) {
+                throw new \Exception('Unable to decode ' . $path . '/' . $this->getComposerFileName());
+            }
+
             if (is_array($json)) {
                 if (isset($json['extra']['installer-paths']) && is_array($json['extra']['installer-paths'])) {
                     foreach ($json['extra']['installer-paths'] as $install_path => $items) {


### PR DESCRIPTION
Fixes https://github.com/drush-ops/drush/issues/3969, and 2 more reports of same.