### PR TITLE
Find the root of the drupal/drupal project.

### DIFF
--- a/src/DrupalFinder.php
+++ b/src/DrupalFinder.php
@@ -115,8 +115,8 @@ class DrupalFinder
                             in_array('drupal/drupal', $items)) {
                             $this->composerRoot = $path;
                             // @todo: Remove this magic and detect the major version instead.
-                            if ($install_path == 'core') {
-                                $install_path = null;
+                            if (($install_path == 'core') || ((isset($json['name'])) && ($json['name'] == 'drupal/drupal'))) {
+                                $install_path = '';
                             } elseif (substr($install_path, -5) == '/core') {
                                 $install_path = substr($install_path, 0, -5);
                             }


### PR DESCRIPTION
The conventions for how the drupal/core project is included from drupal/drupal changed with the removal of the Wikimedia Composer Merge Plugin (see https://www.drupal.org/project/drupal/issues/2912387). These changes broke the assumptions made in drupal/finder. This commit updates the expectations to match the current reality of drupal/drupal.