### PR TITLE
Use web-root specified for the core's scaffold plugin

### DIFF
--- a/src/DrupalFinder.php
+++ b/src/DrupalFinder.php
@@ -108,7 +108,12 @@ class DrupalFinder
             }
 
             if (is_array($json)) {
-                if (isset($json['extra']['installer-paths']) && is_array($json['extra']['installer-paths'])) {
+                if (!empty($json['extra']['drupal-scaffold']['locations']['web-root'])) {
+                    $web_prefix = rtrim($json['extra']['drupal-scaffold']['locations']['web-root'], '/');
+                    $this->composerRoot = $path;
+                    $this->drupalRoot = $path . '/' . $web_prefix;
+                    $this->vendorDir = $path . '/vendor';
+                } elseif (isset($json['extra']['installer-paths']) && is_array($json['extra']['installer-paths'])) {
                     foreach ($json['extra']['installer-paths'] as $install_path => $items) {
                         if (in_array('type:drupal-core', $items) ||
                             in_array('drupal/core', $items) ||


### PR DESCRIPTION
Since the new [core scaffold plugin](https://packagist.org/packages/drupal/core-composer-scaffold) contains a setting for web-root, I think that is the most appropriate setting to determine the path. This PR updates the code to look at that setting first and then the existing approach of `installer-paths`.