### PR TITLE
Failing test: duplicate installer paths

### DIFF
--- a/tests/Drupal8FinderTest.php
+++ b/tests/Drupal8FinderTest.php
@@ -86,6 +86,33 @@ class Drupal8FinderTest extends DrupalFinderTestBase
         return $fileStructure;
     }
 
+    protected function getDrupalComposerStructureWithDuplicateInstallerPaths()
+    {
+        $fileStructure = [
+            'web' => static::$fileStructure,
+            'composer.json' => [
+                'require' => [
+                    'drupal/core' => '*',
+                ],
+                'extra' => [
+                    'installer-paths' => [
+                        'web/core' => [
+                            'type:drupal-core',
+                        ],
+                        'core' => [
+                            'type:drupal-core',
+                        ],
+                    ],
+                ],
+            ],
+            'vendor' => [],
+        ];
+        unset($fileStructure['web']['composer.json']);
+        unset($fileStructure['web']['vendor']);
+
+        return $fileStructure;
+    }
+
     public function testDrupalDefaultStructure()
     {
         $finder = new DrupalFinder();
@@ -255,6 +282,27 @@ class Drupal8FinderTest extends DrupalFinderTestBase
         $finder = new DrupalFinder();
         $root = $this->tempdir(sys_get_temp_dir());
         $this->dumpToFileSystem($this->getDrupalComposerStructure(), $root);
+
+        $this->assertTrue($finder->locateRoot($root));
+        $this->assertSame($root . '/web', $finder->getDrupalRoot());
+        $this->assertSame($root, $finder->getComposerRoot());
+        $this->assertSame($root . '/vendor', $finder->getVendorDir());
+
+        // Test symlink implementation
+        $symlink = $this->tempdir(sys_get_temp_dir());
+        $this->symlink($root, $symlink . '/foo');
+
+        $this->assertTrue($finder->locateRoot($symlink . '/foo'));
+        $this->assertSame($root . '/web', $finder->getDrupalRoot());
+        $this->assertSame($root, $finder->getComposerRoot());
+        $this->assertSame($root . '/vendor', $finder->getVendorDir());
+    }
+
+    public function testDrupalComposerStructureWithDuplicateInstallerPaths()
+    {
+        $finder = new DrupalFinder();
+        $root = $this->tempdir(sys_get_temp_dir());
+        $this->dumpToFileSystem($this->getDrupalComposerStructureWithDuplicateInstallerPaths(), $root);
 
         $this->assertTrue($finder->locateRoot($root));
         $this->assertSame($root . '/web', $finder->getDrupalRoot());


### PR DESCRIPTION
**Problem statement:**

`drupal-finder` has the reverse priority order for installer-paths that `composer/installers` has. This is a problem in a degenerate case, where a site has two entries for `type:drupal-core`. 

- `composer/installers` will take the first entry, installing Drupal to `web/core`
- `drupal-finder` uses the second entry, causing Drush to look for Drupal in `core` instead of `web/core`

Since neither project complains about the duplicate entry, this can cause some head-scratching if the humans don't notice that there's more than one `type:drupal-core` in the long installer-paths list.

**Proposed Solution:**

There are two choices:

- Don't make that mistake again
- Make `drupal-finder` interpret `installer-paths` the same way that `composer/installers` does.

Since humans are fallible, and there are a lot of Drupal sites, I would prefer to go with the second option.