### PR TITLE
Deprecations for PHP 8.1

### DIFF
--- a/tests/DrupalFinderTestBase.php
+++ b/tests/DrupalFinderTestBase.php
@@ -128,7 +128,7 @@ abstract class DrupalFinderTestBase extends TestCase
             $path = $dir . $prefix . mt_rand(0, 9999999);
         } while (!mkdir($path, $mode));
         register_shutdown_function(
-            [get_called_class(), 'tempdir_remove'],
+            [static::class, 'tempdir_remove'],
             $path
         );
 


### PR DESCRIPTION
In scope of PHP8.1 compatibility static analysis it was discovered some deprecations in webflo/drupal-finder codebase:
1. line 56 vendor/webflo/drupal-finder/tests/DrupalFinderTestBase.php get_called_class() without argument (tag 1.2.2)
Proposed change:  replacing get_called_class() with static::class