### PR TITLE
Add new method ::getVendorBin()

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ $drupalFinder = new \DrupalFinder\DrupalFinder(getcwd());
 $drupalRoot = $drupalFinder->getDrupalRoot();
 $composerRoot = $drupalFinder->getComposerRoot();
 $vendorDir = $drupalFinder->getVendorDir();
+$vendorBin = $drupalFinder->getVendorBin();
 ```
 
 ### Environment variables
@@ -23,12 +24,14 @@ values to determine the paths of the pertinent directories:
 - `DRUPAL_FINDER_DRUPAL_ROOT`
 - `DRUPAL_FINDER_COMPOSER_ROOT`
 - `DRUPAL_FINDER_VENDOR_DIR`
+- `DRUPAL_FINDER_VENDOR_DIR`
 
 For example:
 
 - `DRUPAL_FINDER_DRUPAL_ROOT=/var/www/web`
 - `DRUPAL_FINDER_COMPOSER_ROOT=/var/www`
 - `DRUPAL_FINDER_VENDOR_DIR=/var/www/vendor`
+- `DRUPAL_FINDER_VENDOR_BIN=/var/www/vendor/bin`
 
 This is useful for situations where you are containerizing an application,
 directories may be in odd places, or a composer.json might be missing since it


### PR DESCRIPTION
As part of this change I investigated a few projects to see how they are doing this such as upgrade status and upgrade rector and they both have something similar to this but both do it in different ways.

I think this is the definitive method of determining the vendor bin and gives a centralised method of accessing this information so many projects doing have to add it themselves.

One minor issue i found this this is that in my clients config the config.bin-dir is set to `bin/` which means that when the vendor dir is returned it has the trailing /. so when you do something like

`$bin = $drupalFinder->getVendorDir() . '/rector';`

you will get `/composer_root/bin//rector`. this is ok, but a little messy. But I am also assuming it you set config.vendor-dir to something like 'vendor-here/' then the same issue will happen.